### PR TITLE
Add support for flash.nvim labels

### DIFF
--- a/colors/xcodedarkhc.vim
+++ b/colors/xcodedarkhc.vim
@@ -58,6 +58,8 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   if !exists('g:xcodedarkhc_dim_punctuation')
     let g:xcodedarkhc_dim_punctuation = 1
   endif
+  " support for folke/flash.nvim
+  hi FlashLabel guifg=#1f1f24 guibg=#ff85b8 gui=bold cterm=bold
   hi Normal guifg=#ffffff guibg=#1f1f24 gui=NONE cterm=NONE
   hi Cursor guifg=#1f1f24 guibg=#ffffff gui=NONE cterm=NONE
   hi Empty guifg=#ffffff guibg=NONE gui=NONE cterm=NONE


### PR DESCRIPTION
Add support for the plugin folke/flash.nvim in order to highlight and make visible the labels created while jumping through the code.
![Screen Shot 2024-10-21 at 10 15 03 AM](https://github.com/user-attachments/assets/215628f6-398f-41cf-821e-156bfe8c3358)
