### PR TITLE
Add support for flash.nvim labels

### DIFF
--- a/colors/xcode.vim
+++ b/colors/xcode.vim
@@ -51,6 +51,8 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
     if !exists('g:xcode_dim_punctuation')
       let g:xcode_dim_punctuation = 1
     endif
+    " support for folke/flash.nvim
+    hi FlashLabel guifg=#1f1f24 guibg=#ff7ab2 gui=bold cterm=bold
     hi Normal guifg=#dfdfe0 guibg=#292a30 gui=NONE cterm=NONE
     hi Cursor guifg=#292a30 guibg=#dfdfe0 gui=NONE cterm=NONE
     hi None guifg=#dfdfe0 guibg=NONE gui=NONE cterm=NONE

--- a/colors/xcodedark.vim
+++ b/colors/xcodedark.vim
@@ -58,6 +58,8 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   if !exists('g:xcodedark_dim_punctuation')
     let g:xcodedark_dim_punctuation = 1
   endif
+  " support for folke/flash.nvim
+  hi FlashLabel guifg=#1f1f24 guibg=#ff7ab2 gui=bold cterm=bold
   hi Normal guifg=#dfdfe0 guibg=#292a30 gui=NONE cterm=NONE
   hi Cursor guifg=#292a30 guibg=#dfdfe0 gui=NONE cterm=NONE
   hi Empty guifg=#dfdfe0 guibg=NONE gui=NONE cterm=NONE

--- a/colors/xcodedarkhc.vim
+++ b/colors/xcodedarkhc.vim
@@ -58,6 +58,8 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   if !exists('g:xcodedarkhc_dim_punctuation')
     let g:xcodedarkhc_dim_punctuation = 1
   endif
+  " support for folke/flash.nvim
+  hi FlashLabel guifg=#1f1f24 guibg=#ff85b8 gui=bold cterm=bold
   hi Normal guifg=#ffffff guibg=#1f1f24 gui=NONE cterm=NONE
   hi Cursor guifg=#1f1f24 guibg=#ffffff gui=NONE cterm=NONE
   hi Empty guifg=#ffffff guibg=NONE gui=NONE cterm=NONE

--- a/colors/xcodehc.vim
+++ b/colors/xcodehc.vim
@@ -51,6 +51,8 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
     if !exists('g:xcodehc_dim_punctuation')
       let g:xcodehc_dim_punctuation = 1
     endif
+    " support for folke/flash.nvim
+    hi FlashLabel guifg=#1f1f24 guibg=#ff85b8 gui=bold cterm=bold
     hi Normal guifg=#ffffff guibg=#1f1f24 gui=NONE cterm=NONE
     hi Cursor guifg=#1f1f24 guibg=#ffffff gui=NONE cterm=NONE
     hi None guifg=#ffffff guibg=NONE gui=NONE cterm=NONE

--- a/colors/xcodelight.vim
+++ b/colors/xcodelight.vim
@@ -58,6 +58,8 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   if !exists('g:xcodelight_dim_punctuation')
     let g:xcodelight_dim_punctuation = 1
   endif
+  " support for folke/flash.nvim
+  hi FlashLabel guifg=#1f1f24 guibg=#ad3da4 gui=bold cterm=bold
   hi Normal guifg=#262626 guibg=#ffffff gui=NONE cterm=NONE
   hi Cursor guifg=#ffffff guibg=#262626 gui=NONE cterm=NONE
   hi Empty guifg=#262626 guibg=NONE gui=NONE cterm=NONE

--- a/colors/xcodelighthc.vim
+++ b/colors/xcodelighthc.vim
@@ -58,6 +58,8 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   if !exists('g:xcodelighthc_dim_punctuation')
     let g:xcodelighthc_dim_punctuation = 1
   endif
+  " support for folke/flash.nvim
+  hi FlashLabel guifg=#1f1f24 guibg=#9c2191 gui=bold cterm=bold
   hi Normal guifg=#000000 guibg=#ffffff gui=NONE cterm=NONE
   hi Cursor guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
   hi Empty guifg=#000000 guibg=NONE gui=NONE cterm=NONE

--- a/colors/xcodewwdc.vim
+++ b/colors/xcodewwdc.vim
@@ -58,6 +58,8 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   if !exists('g:xcodewwdc_dim_punctuation')
     let g:xcodewwdc_dim_punctuation = 1
   endif
+  " support for folke/flash.nvim
+  hi FlashLabel guifg=#1f1f24 guibg=#b73999 gui=bold cterm=bold
   hi Normal guifg=#e7e8eb guibg=#292c36 gui=NONE cterm=NONE
   hi Cursor guifg=#292c36 guibg=#e7e8eb gui=NONE cterm=NONE
   hi Empty guifg=#e7e8eb guibg=NONE gui=NONE cterm=NONE


### PR DESCRIPTION
Add support for folke/flash.nvim adding colors to the labels created from the plugin while jumping around the code.

The screenshot is an example in the colorscheme variant `xcodedarkhc`

![Screen Shot 2024-10-21 at 10 15 03 AM](https://github.com/user-attachments/assets/c3bafc2d-4c4b-49a8-a889-b05002be5d7c)
